### PR TITLE
Fixed double slash url.

### DIFF
--- a/sitemap.php
+++ b/sitemap.php
@@ -203,7 +203,10 @@ function get_links($html, $parent_url)
                         logger("URL is an invalid protocol", 1);
                         return false;
                     }
-                    if ($href == '/') {
+                    if ($href == '/' && !$html) {
+                        logger("Fixed double slash url", 2);
+                        $href = $real_site;
+                    } elseif ($href == '/') {
                         logger("$href is domain root", 2);
                         $href = $real_site . $href;
                     } elseif (substr($href, 0, 1) == '/') {


### PR DESCRIPTION
I tested the script with some websites, and sometimes it adds the home path with a double slash, like this:

[+] Added: http://test.com/
[+] Added: http://test.com//

The patch detects the double slash url and converts it to have only one slash.