### PR TITLE
Removed cli colors from Windows as it just throws garbage

### DIFF
--- a/sitemap.php
+++ b/sitemap.php
@@ -19,7 +19,7 @@ header("Content-Type: text/plain");
 $color = false;
 
 // Add PHP CLI support
-if (php_sapi_name() === 'cli') {
+if (php_sapi_name() === 'cli' && PHP_OS != 'WINNT') {
     parse_str(implode('&', array_slice($argv, 1)), $args);
     $color = true;
 }


### PR DESCRIPTION
The default command prompt doesn't handle color expressions very well (or rather at all) and this PR removes it.

I am also trying out how a 2-branch system would work.