### PR TITLE
Memory leak reduction

### DIFF
--- a/sitemap.functions.php
+++ b/sitemap.functions.php
@@ -215,6 +215,7 @@ function get_data($url)
         if (strpos($redirect_url, '?') !== false) {
 	     $redirect_url = explode($redirect_url, "?")[0];
 	}
+	unset($url,$data);
 	scan_url($redirect_url);
     }
 
@@ -376,7 +377,8 @@ function scan_url($url)
     fwrite($file_stream, $map_row);
     $indexed++;
     logger("Added: " . $url . ((!empty($modified)) ? " [Modified: " . $modified . "]" : ''), 0);
-
+    unset($is_image,$map_row);
+    
     // Extract urls from <a href="??"></a>
     $ahrefs = get_links($html, $url, "<a\s[^>]*href=(\"|'??)([^\" >]*?)\\1[^>]*>(.*)<\/a>");
     // Extract urls from <frame src="??">
@@ -385,6 +387,8 @@ function scan_url($url)
     $links = array_filter(array_merge($ahrefs, $framesrc), function ($item){
         return $item;
     });
+    unset($html,$url,$ahrefs,$framesrc);
+    
     logger("Found urls: " . join(", ", $links), 2);
     foreach ($links as $href) {
         if ($href) {


### PR DESCRIPTION
Freeing unnecessary variables before going for subsequent pages reduces memory leak since things like previous page's html don't need to wait until all subpages are surfed. [Example chart](https://snag.gy/eW5CHK.jpg): [before.log](https://github.com/knyzorg/Sitemap-Generator-Crawler/files/1561071/before.log), [after.log](https://github.com/knyzorg/Sitemap-Generator-Crawler/files/1561070/after.log).

#26 