### PR TITLE
Don't mark redirects as scanned before scanning them

### DIFF
--- a/sitemap.functions.php
+++ b/sitemap.functions.php
@@ -191,7 +191,7 @@ function domain_root($href)
 $curl_client = curl_init();
 function get_data($url)
 {
-    global $curl_validate_certificate, $curl_client, $index_pdf, $crawler_user_agent;
+    global $curl_validate_certificate, $curl_client, $index_pdf, $index_img, $crawler_user_agent;
 
     //Set URL
     curl_setopt($curl_client, CURLOPT_URL, $url);
@@ -236,7 +236,7 @@ function get_data($url)
         $html = "This is a PDF";
     }
     //Return it as an array
-    return array($html, $modified, (stripos($content_type, "image/") && $index_img));
+    return array($html, $modified, ((stripos($content_type, "image/")!==false) && $index_img));
 }
 
 //Try to match string against blacklist

--- a/sitemap.functions.php
+++ b/sitemap.functions.php
@@ -344,12 +344,12 @@ function scan_url($url)
         logger("Maximum depth exceeded. Rejecting.", 1);
         return $depth--;
     }
-
-    //Note that URL has been scanned
-    $scanned[$url] = 1;
     
     //Send cURL request
     list($html, $modified, $is_image) = get_data($url);
+
+    //Note that URL has been scanned
+    $scanned[$url] = 1;
 
     if ($is_image) {
         //Url is an image


### PR DESCRIPTION
Currently pages, including redirects are marked as scanned before they are actually scanned. If the page redirects from a link without trailing / to a link with / (e.g. www.pronobis.pro/publications/zheng2018aaai redirects to www.pronobis.pro/publications/zheng2018aaai/), then the page will never be scanned (the scanner considers both links to refer to the same page, and the one without / is already added as scanned).

This simple change fixes it for me, although, I'm not sure if there won't be any unintended consequences.